### PR TITLE
Add detached_from_id and aggregator_id to events

### DIFF
--- a/l1/src/L1MessagesSender.sol
+++ b/l1/src/L1MessagesSender.sol
@@ -71,7 +71,7 @@ contract L1MessagesSender is Ownable {
         require(mmrSize >= 1, "Invalid tree size");
         require(poseidonMMRRoot != bytes32(0), "Invalid root (Poseidon)");
 
-        _sendPoseidonMMRTreeToL2(poseidonMMRRoot, mmrSize);
+        _sendPoseidonMMRTreeToL2(poseidonMMRRoot, mmrSize, aggregatorId);
     }
 
     function _sendBlockHashToL2(
@@ -97,12 +97,14 @@ contract L1MessagesSender is Ownable {
 
     function _sendPoseidonMMRTreeToL2(
         bytes32 poseidonMMRRoot,
-        uint256 mmrSize
+        uint256 mmrSize,
+        uint256 aggregatorId
     ) internal {
-        uint256[] memory message = new uint256[](2);
+        uint256[] memory message = new uint256[](3);
 
         message[0] = uint256(poseidonMMRRoot);
         message[1] = mmrSize;
+        message[2] = aggregatorId;
 
         // Pass along msg.value
         starknetCore.sendMessageToL2{value: msg.value}(

--- a/src/core/commitments_inbox.cairo
+++ b/src/core/commitments_inbox.cairo
@@ -80,7 +80,8 @@ mod CommitmentsInbox {
     #[derive(Drop, starknet::Event)]
     struct MMRReceived {
         root: felt252,
-        last_pos: usize
+        last_pos: usize,
+        aggregator_id: usize
     }
 
     #[constructor]
@@ -170,12 +171,19 @@ mod CommitmentsInbox {
     }
 
     #[l1_handler]
-    fn receive_mmr(ref self: ContractState, from_address: felt252, root: felt252, last_pos: usize) {
+    fn receive_mmr(
+        ref self: ContractState,
+        from_address: felt252,
+        root: felt252,
+        last_pos: usize,
+        aggregator_id: usize
+    ) {
         assert(from_address == self.l1_message_sender.read().into(), 'Invalid sender');
 
         let contract_address = self.headers_store.read();
-        IHeadersStoreDispatcher { contract_address }.create_branch_from_message(root, last_pos);
+        IHeadersStoreDispatcher { contract_address }
+            .create_branch_from_message(root, last_pos, aggregator_id);
 
-        self.emit(Event::MMRReceived(MMRReceived { root, last_pos }));
+        self.emit(Event::MMRReceived(MMRReceived { root, last_pos, aggregator_id }));
     }
 }

--- a/src/remappers/tests/test_timestamp_remappers.cairo
+++ b/src/remappers/tests/test_timestamp_remappers.cairo
@@ -379,7 +379,7 @@ fn test_remappers() {
     start_prank(headers_store, 0.try_into().unwrap());
     headers_store_dispatcher
         .create_branch_from_message(
-            0x25aedbc0ddea804ce21d29a39f00358f68df0e462114f75b0576182d08db0, 4
+            0x25aedbc0ddea804ce21d29a39f00358f68df0e462114f75b0576182d08db0, 4, 1
         );
     stop_prank(headers_store);
 


### PR DESCRIPTION
- Adds `detached_from_id` to the`BranchCreated` event (i.e., when detaching from an L2 tree).
- Adds `aggregator_id` to the `BranchCreatedFromL1` event (i.e., when a L1 -> L2 message is received).
- Adds `aggregator_id` to the `MMRReceived` event.
- Updates the Solidity L1MessagesSender to specify the `aggregatorId` when sending a tree state.